### PR TITLE
Fixed typo in comment

### DIFF
--- a/Java/Ch 02. Linked Lists/Q2_02_Return_Kth_To_Last/QuestionD.java
+++ b/Java/Ch 02. Linked Lists/Q2_02_Return_Kth_To_Last/QuestionD.java
@@ -8,7 +8,7 @@ public class QuestionD {
 		LinkedListNode p1 = head;
 		LinkedListNode p2 = head;
 		
-		/* Move p2 k nodes into the list.*/
+		/* Move p1 k nodes into the list.*/
 		for (int i = 0; i < k; i++) {
 			if (p1 == null) return null; // Out of bounds
 			p1 = p1.next;


### PR DESCRIPTION
In the loop immediately below the comment, p1 is moving forward, not p2.