### PR TITLE
AssortedMethods: check valid argument for randomIntInRange

### DIFF
--- a/Java/Ch 07. Object-Oriented Design/Q7_01_Deck_of_Cards/Deck.java
+++ b/Java/Ch 07. Object-Oriented Design/Q7_01_Deck_of_Cards/Deck.java
@@ -17,7 +17,7 @@ public class Deck <T extends Card> {
 	
 	public void shuffle() {
 		for (int i = 0; i < cards.size(); i++) {
-			int j = AssortedMethods.randomIntInRange(i, cards.size() - i - 1);
+			int j = AssortedMethods.randomIntInRange(i, cards.size() - 1);
 			T card1 = cards.get(i);
 			T card2 = cards.get(j);
 			cards.set(i, card2);

--- a/Java/CtCILibrary/CtCILibrary/AssortedMethods.java
+++ b/Java/CtCILibrary/CtCILibrary/AssortedMethods.java
@@ -9,7 +9,10 @@ public class AssortedMethods {
 	}
 
 	public static int randomIntInRange(int min, int max) {
-		return randomInt(max + 1 - min) + min;
+		int range = max + 1 - min;
+		if (!(range > 0))
+			throw new IllegalArgumentException("range must be > 0, it is " + range);
+		return randomInt(range) + min;
 	}
 
 	public static boolean randomBoolean() {


### PR DESCRIPTION
When generating a random number from a range, this range must contain at least one number, otherwise no valid return value is possible.

Therefore, a check has been added that ensures this property.
All programs that fail because of this check were broken before anyway.

For example, when shuffling a Deck of 52 cards in Q7_01, the card with index 51 could never end up at index 1 after shuffling.

Before: unfair shuffle (index before shuffling is at the left, index after shuffling is at the top)
![unfair shuffle](https://user-images.githubusercontent.com/3233724/27751331-1311b652-5ddc-11e7-847b-c2ae9dd98ec7.png)

After: fair shuffle (index before shuffling is at the left, index after shuffling is at the top)
![fair shuffle](https://user-images.githubusercontent.com/3233724/27751339-195ac3c8-5ddc-11e7-8356-b96efc0baa5c.png)
