### PR TITLE
Change HashMap to HashSet for lookup field

### DIFF
--- a/Java/Ch 17. Hard/Q17_25_Word_Rectangle/WordGroup.java
+++ b/Java/Ch 17. Hard/Q17_25_Word_Rectangle/WordGroup.java
@@ -5,7 +5,7 @@ import java.util.HashMap;
 
 /* A container for a group of words of the same length. */
 public class WordGroup {
-	private HashMap<String, Boolean> lookup = new HashMap<String, Boolean>();
+	private HashSet<String> lookup = new HashSet<String>();
     private ArrayList<String> group = new ArrayList<String>();
     
     public WordGroup() {
@@ -18,7 +18,7 @@ public class WordGroup {
     
     public void addWord (String s) {
         group.add(s);
-        lookup.put(s, true);
+        lookup.put(s);
     }
     
     public int length() {


### PR DESCRIPTION
There is no need of using a HashMap data type for lookup field. As the boolean value of it is never used.