### PR TITLE
Add `Rust/`-Lang Solutions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -46,3 +46,6 @@
 [submodule "Kotlin"]
 	path = Kotlin
 	url = https://github.com/careercup/CtCI-6th-Edition-Kotlin.git
+[submodule "Rust"]
+	path = Rust
+	url = https://github.com/dan-fritchman/CtCI-6th-Edition-Rust.git


### PR DESCRIPTION
Adding a `git submodule` link to the Rust-lang solutions available at https://github.com/dan-fritchman/CtCI-6th-Edition-Rust.git. 

Appreciate the work everyone here has done assembling these examples. Hope another language-worth of them can help. 

Feedback welcome on the solutions themselves, whether you'd like to add the language, or anything else. 
