### PR TITLE
FIX(security): macOS File DIr Store as per apple.developer forums

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 bin/
+.DS_Store


### PR DESCRIPTION
the macOs .DS_Store stores fileSystem
info and should be ignored by the
versioning tool.

.gitignore update!

**Please refer :** 
[developer.apple](https://developer.apple.com/forums/thread/30532)
[wikipediaDSstore](https://en.wikipedia.org/wiki/.DS_Store) , [popular_blogpost](https://buildthis.com/ds_store-files-and-why-you-should-know-about-them/)

screenshots before .gitignore update:
<img width="650" alt="image" src="https://user-images.githubusercontent.com/55528510/170767679-264ad9fc-6a7c-4808-85af-06dc849f28c9.png">

screenshots before .gitignore update:
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/55528510/170767695-7ce8d537-ad4b-4912-8cc8-80f001ecdef0.png">

