### PR TITLE
Update MultiStack.java

### DIFF
--- a/Java/Ch 03. Stacks and Queues/Q3_01_Three_in_One/MultiStack.java
+++ b/Java/Ch 03. Stacks and Queues/Q3_01_Three_in_One/MultiStack.java
@@ -112,7 +112,7 @@ public class MultiStack {
 		}
 		
 		/* Shift all elements in stack over by one. */
-		int index = stack.lastCapacityIndex();
+		int index = nextIndex(stack.lastElementIndex());
 		while (stack.isWithinStackCapacity(index)) {
 			values[index] = values[previousIndex(index)];
 			index = previousIndex(index);


### PR DESCRIPTION
We should use lastElementIndex instead of lastCapacityIndex. In the current approach, all elements will move to the very end of the capacity, not necessarily one forward.